### PR TITLE
feat(canvas): replace polling with WebSocket real-time sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "date-fns": "^4.1.0",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
-    "helmet": "^8.1.0"
+    "helmet": "^8.1.0",
+    "ws": "^8.20.0"
   },
   "devDependencies": {
     "@codemirror/lang-sql": "^6.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
     devDependencies:
       '@codemirror/lang-sql':
         specifier: ^6.10.0
@@ -3204,6 +3207,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xlsx-js-style@1.2.0:
     resolution: {integrity: sha512-DDT4FXFSWfT4DXMSok/m3TvmP1gvO3dn0Eu/c+eXHW5Kzmp7IczNkxg/iEPnImbG9X0Vb8QhROda5eatSR/97Q==}
     engines: {node: '>=0.8'}
@@ -6254,6 +6269,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
 
   xlsx-js-style@1.2.0:
     dependencies:

--- a/server.js
+++ b/server.js
@@ -1,7 +1,9 @@
+import http from 'http'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
 import { createApp } from './src/server/app.js'
+import { createCanvasWebSocketServer } from './src/server/websocket/canvasWebSocketServer.js'
 import { registerFrontend } from './src/server/frontend/serveFrontend.js'
 import { createBigQueryClient } from './src/server/bigquery/client.js'
 import { createBigQueryRouter } from './src/server/routes/bigquery/index.js'
@@ -47,7 +49,11 @@ registerFrontend(app, { buildPath, GCP_PROJECT_ID })
 const isProduction = process.env.NODE_ENV === 'production'
 const port = Number(process.env.PORT) || (isProduction ? 8080 : 8081)
 
-const server = app.listen(port, () => {
+const httpServer = http.createServer(app)
+createCanvasWebSocketServer(httpServer)
+
+const server = httpServer
+httpServer.listen(port, () => {
   console.log(`Listening on port ${port}`)
   console.log('Server timeout set to 2 minutes')
 })

--- a/src/client/features/canvas/hooks/useCanvasBackgroundSync.ts
+++ b/src/client/features/canvas/hooks/useCanvasBackgroundSync.ts
@@ -3,6 +3,7 @@ import type { Dispatch, SetStateAction } from 'react'
 import type { GraphCategoryDto } from '../../oversikt/model/types.ts'
 import type { CanvasConnection, CanvasFrame } from '../model/types.ts'
 import { fetchCanvasStorageData } from '../api/canvasStorageApi.ts'
+import type { CanvasWebSocketHandle } from './useCanvasWebSocket.ts'
 
 const DEFAULT_SYNC_INTERVAL_MS = 4000
 const MAX_SYNC_INTERVAL_MS = 30000
@@ -181,6 +182,7 @@ type UseCanvasBackgroundSyncParams = {
   setSyncError: Dispatch<SetStateAction<string | null>>
   onBeforeApplyRemoteData?: () => void
   intervalMs?: number
+  ws?: CanvasWebSocketHandle
 }
 
 const useCanvasBackgroundSync = ({
@@ -197,7 +199,18 @@ const useCanvasBackgroundSync = ({
   setSyncError,
   onBeforeApplyRemoteData,
   intervalMs = DEFAULT_SYNC_INTERVAL_MS,
+  ws,
 }: UseCanvasBackgroundSyncParams) => {
+  useEffect(() => {
+    if (!ws) return
+    const unsubscribe = ws.subscribe('canvas:frame', (payload) => {
+      const frame = payload as CanvasFrame
+      if (!frame?.id) return
+      setFrames((current) => reconcileFrames(current, [frame], new Set()))
+    })
+    return unsubscribe
+  }, [ws, setFrames])
+
   useEffect(() => {
     if (!enabled || projectId === null || dashboardId === null) return
 

--- a/src/client/features/canvas/hooks/useCanvasDotVotingSync.ts
+++ b/src/client/features/canvas/hooks/useCanvasDotVotingSync.ts
@@ -12,6 +12,7 @@ import {
   type CanvasDotVotingBallotPayload,
   type CanvasDotVotingSessionPayload,
 } from '../api/canvasDotVotingApi.ts'
+import type { CanvasWebSocketHandle } from './useCanvasWebSocket.ts'
 
 const DOT_VOTING_ACTIVE_SYNC_INTERVAL_MS = 2000
 const DOT_VOTING_IDLE_SYNC_INTERVAL_MS = 10000
@@ -30,6 +31,7 @@ type UseCanvasDotVotingSyncParams = {
   projectId: number | null
   dashboardId: number | null
   onSyncError?: (message: string) => void
+  ws?: CanvasWebSocketHandle
 }
 
 const useCanvasDotVotingSync = ({
@@ -39,6 +41,7 @@ const useCanvasDotVotingSync = ({
   projectId,
   dashboardId,
   onSyncError,
+  ws,
 }: UseCanvasDotVotingSyncParams) => {
   const [sessionPayload, setSessionPayload] = useState<CanvasDotVotingSessionPayload | null>(null)
   const [ballots, setBallots] = useState<CanvasDotVotingBallotPayload[]>([])
@@ -46,15 +49,35 @@ const useCanvasDotVotingSync = ({
   const [nowMs, setNowMs] = useState(() => Date.now())
   const [isSavingVoting, setIsSavingVoting] = useState(false)
   const onSyncErrorRef = useRef<typeof onSyncError>(onSyncError)
+  const wsRef = useRef(ws)
 
   useEffect(() => {
     onSyncErrorRef.current = onSyncError
   }, [onSyncError])
 
   useEffect(() => {
+    wsRef.current = ws
+  })
+
+  useEffect(() => {
     const intervalId = window.setInterval(() => setNowMs(Date.now()), 1000)
     return () => window.clearInterval(intervalId)
   }, [])
+
+  useEffect(() => {
+    if (!ws) return
+    const fromWsRef = { current: false }
+    const unsubscribe = ws.subscribe('canvas:dotvoting', (payload) => {
+      const data = payload as { session: CanvasDotVotingSessionPayload | null; ballots: CanvasDotVotingBallotPayload[] }
+      if (data && typeof data === 'object') {
+        fromWsRef.current = true
+        setSessionPayload(data.session ?? null)
+        setBallots(Array.isArray(data.ballots) ? data.ballots : [])
+        fromWsRef.current = false
+      }
+    })
+    return unsubscribe
+  }, [ws])
 
   useEffect(() => {
     let isActive = true
@@ -178,6 +201,7 @@ const useCanvasDotVotingSync = ({
         })
         setSessionPayload(nextSession)
         setBallots([])
+        wsRef.current?.broadcast('canvas:dotvoting', { session: nextSession, ballots: [] })
       } catch (error) {
         onSyncError?.(error instanceof Error ? error.message : 'Kunne ikke starte prikkvotering')
       } finally {
@@ -193,6 +217,7 @@ const useCanvasDotVotingSync = ({
       setIsSavingVoting(true)
       const nextSession = await pauseCanvasDotVoting(projectId, dashboardId)
       setSessionPayload(nextSession)
+      wsRef.current?.broadcast('canvas:dotvoting', { session: nextSession, ballots: [] })
     } catch (error) {
       onSyncError?.(error instanceof Error ? error.message : 'Kunne ikke pause prikkvotering')
     } finally {
@@ -206,6 +231,7 @@ const useCanvasDotVotingSync = ({
       setIsSavingVoting(true)
       const nextSession = await resumeCanvasDotVoting(projectId, dashboardId)
       setSessionPayload(nextSession)
+      wsRef.current?.broadcast('canvas:dotvoting', { session: nextSession, ballots: [] })
     } catch (error) {
       onSyncError?.(error instanceof Error ? error.message : 'Kunne ikke fortsette prikkvotering')
     } finally {
@@ -223,6 +249,7 @@ const useCanvasDotVotingSync = ({
         setIsSavingVoting(true)
         const nextSession = await adjustCanvasDotVoting(projectId, dashboardId, deltaSeconds)
         setSessionPayload(nextSession)
+        wsRef.current?.broadcast('canvas:dotvoting', { session: nextSession, ballots: [] })
       } catch (error) {
         onSyncError?.(error instanceof Error ? error.message : 'Kunne ikke oppdatere prikkvotering')
       } finally {
@@ -238,6 +265,7 @@ const useCanvasDotVotingSync = ({
       setIsSavingVoting(true)
       const nextSession = await endCanvasDotVoting(projectId, dashboardId)
       setSessionPayload(nextSession)
+      wsRef.current?.broadcast('canvas:dotvoting', { session: nextSession, ballots: [] })
     } catch (error) {
       onSyncError?.(error instanceof Error ? error.message : 'Kunne ikke avslutte prikkvotering')
     } finally {
@@ -252,6 +280,7 @@ const useCanvasDotVotingSync = ({
       await clearCanvasDotVoting(projectId, dashboardId)
       setSessionPayload(null)
       setBallots([])
+      wsRef.current?.broadcast('canvas:dotvoting', { session: null, ballots: [] })
     } catch (error) {
       onSyncError?.(error instanceof Error ? error.message : 'Kunne ikke nullstille prikkvotering')
     } finally {

--- a/src/client/features/canvas/hooks/useCanvasEditLocks.ts
+++ b/src/client/features/canvas/hooks/useCanvasEditLocks.ts
@@ -7,6 +7,7 @@ import {
   releaseCanvasEditLock,
   type CanvasEditLockRecord,
 } from '../api/canvasEditLockApi.ts'
+import type { CanvasWebSocketHandle } from './useCanvasWebSocket.ts'
 
 const LOCK_SYNC_INTERVAL_MS = 3000
 
@@ -41,6 +42,7 @@ type UseCanvasEditLocksParams = {
   dashboardId: number | null
   activeEditableFrame: CanvasFrame | null
   onLostActiveLock?: () => void
+  ws?: CanvasWebSocketHandle
 }
 
 const useCanvasEditLocks = ({
@@ -49,6 +51,7 @@ const useCanvasEditLocks = ({
   dashboardId,
   activeEditableFrame,
   onLostActiveLock,
+  ws,
 }: UseCanvasEditLocksParams) => {
   const editorId = useMemo(() => createEditorId(), [])
   const editorLabel = 'En kollega'
@@ -56,6 +59,20 @@ const useCanvasEditLocks = ({
     Record<number, { ownerId: string; ownerLabel: string; expiresAt: string }>
   >({})
   const isPollingRef = useRef(false)
+  const wsRef = useRef(ws)
+  useEffect(() => {
+    wsRef.current = ws
+  })
+
+  useEffect(() => {
+    if (!ws) return
+    return ws.subscribe('canvas:locks', (payload) => {
+      const nextLocks = payload as Record<number, { ownerId: string; ownerLabel: string; expiresAt: string }>
+      if (nextLocks && typeof nextLocks === 'object') {
+        setActiveLocksByFrameGraphId(nextLocks)
+      }
+    })
+  }, [ws])
 
   const syncLocks = useCallback(async () => {
     if (!enabled || projectId === null || dashboardId === null) return
@@ -67,6 +84,7 @@ const useCanvasEditLocks = ({
       const records = await listCanvasEditLocks(projectId, dashboardId)
       const nextLocks = toActiveLocksByFrameGraphId(records)
       setActiveLocksByFrameGraphId(nextLocks)
+      wsRef.current?.broadcast('canvas:locks', nextLocks)
 
       const activeFrameGraphId = activeEditableFrame?.graphId
       if (!activeFrameGraphId) return

--- a/src/client/features/canvas/hooks/useCanvasPresence.ts
+++ b/src/client/features/canvas/hooks/useCanvasPresence.ts
@@ -5,6 +5,7 @@ import {
   sendCanvasPresenceHeartbeat,
   type CanvasParticipant,
 } from '../api/canvasPresenceApi.ts'
+import type { CanvasWebSocketHandle } from './useCanvasWebSocket.ts'
 
 const PRESENCE_HEARTBEAT_MS = 10000
 const PRESENCE_POLL_MS = 10000
@@ -20,9 +21,10 @@ type UseCanvasPresenceParams = {
   enabled: boolean
   projectId: number | null
   dashboardId: number | null
+  ws?: CanvasWebSocketHandle
 }
 
-const useCanvasPresence = ({ enabled, projectId, dashboardId }: UseCanvasPresenceParams) => {
+const useCanvasPresence = ({ enabled, projectId, dashboardId, ws }: UseCanvasPresenceParams) => {
   const [clientId] = useState<string>(() => createCanvasClientId())
   const [ownerId, setOwnerId] = useState<string>('')
   const [ownerLabel, setOwnerLabel] = useState<string>('En kollega')
@@ -49,6 +51,8 @@ const useCanvasPresence = ({ enabled, projectId, dashboardId }: UseCanvasPresenc
     }
   }, [])
 
+  const wsConnected = ws?.isConnected ?? false
+
   useEffect(() => {
     if (!enabled || projectId === null || dashboardId === null) return
 
@@ -71,34 +75,51 @@ const useCanvasPresence = ({ enabled, projectId, dashboardId }: UseCanvasPresenc
       if (!isActive) return
       setParticipants(nextParticipants)
       setIsPresenceReady(true)
+      ws?.broadcast('canvas:presence', nextParticipants)
     }
 
     const runTick = async () => {
       if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return
       try {
         await sendHeartbeat()
-        await pollParticipants()
+        if (!wsConnected) await pollParticipants()
       } catch {
         // Presence errors should not block canvas usage.
       }
     }
 
     void runTick()
+
     heartbeatId = window.setInterval(() => {
       void sendHeartbeat().catch(() => undefined)
     }, PRESENCE_HEARTBEAT_MS)
-    pollId = window.setInterval(() => {
-      void pollParticipants().catch(() => undefined)
-    }, PRESENCE_POLL_MS)
+
+    if (!wsConnected) {
+      pollId = window.setInterval(() => {
+        void pollParticipants().catch(() => undefined)
+      }, PRESENCE_POLL_MS)
+    }
 
     return () => {
       isActive = false
       if (heartbeatId !== null) window.clearInterval(heartbeatId)
       if (pollId !== null) window.clearInterval(pollId)
     }
-  }, [clientId, dashboardId, enabled, ownerId, ownerLabel, projectId])
+  }, [clientId, dashboardId, enabled, ownerId, ownerLabel, projectId, ws, wsConnected])
 
   const effectiveParticipants = useMemo(() => (enabled ? participants : []), [enabled, participants])
+
+  useEffect(() => {
+    if (!ws) return
+    const unsubscribe = ws.subscribe('canvas:presence', (payload) => {
+      const next = payload as CanvasParticipant[]
+      if (Array.isArray(next)) {
+        setParticipants(next)
+        setIsPresenceReady(true)
+      }
+    })
+    return unsubscribe
+  }, [ws])
   const effectivePresenceReady = enabled ? isPresenceReady : false
   const uniqueParticipants = useMemo(() => {
     const byOwnerKey = new Map<string, CanvasParticipant>()

--- a/src/client/features/canvas/hooks/useCanvasTimerSync.ts
+++ b/src/client/features/canvas/hooks/useCanvasTimerSync.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   adjustCanvasTimer,
   clearCanvasTimer,
@@ -8,6 +8,7 @@ import {
   upsertCanvasTimer,
   type CanvasTimerPayload,
 } from '../api/canvasTimerApi.ts'
+import type { CanvasWebSocketHandle } from './useCanvasWebSocket.ts'
 
 const TIMER_ACTIVE_SYNC_INTERVAL_MS = 2000
 const TIMER_FINISHED_VISIBLE_MS = 15000
@@ -24,12 +25,24 @@ type UseCanvasTimerSyncParams = {
   projectId: number | null
   dashboardId: number | null
   onSyncError?: (message: string) => void
+  ws?: CanvasWebSocketHandle
 }
 
-const useCanvasTimerSync = ({ enabled, projectId, dashboardId, onSyncError }: UseCanvasTimerSyncParams) => {
+const useCanvasTimerSync = ({ enabled, projectId, dashboardId, onSyncError, ws }: UseCanvasTimerSyncParams) => {
   const [timerPayload, setTimerPayload] = useState<CanvasTimerPayload | null>(null)
   const [nowMs, setNowMs] = useState(() => Date.now())
   const [isSavingTimer, setIsSavingTimer] = useState(false)
+  const wsRef = useRef(ws)
+  useEffect(() => {
+    wsRef.current = ws
+  })
+
+  useEffect(() => {
+    if (!ws) return
+    return ws.subscribe('canvas:timer', (payload) => {
+      setTimerPayload((payload as CanvasTimerPayload | null) ?? null)
+    })
+  }, [ws])
 
   useEffect(() => {
     const intervalId = window.setInterval(() => setNowMs(Date.now()), 1000)
@@ -97,6 +110,7 @@ const useCanvasTimerSync = ({ enabled, projectId, dashboardId, onSyncError }: Us
           durationSeconds,
         })
         setTimerPayload(nextPayload)
+        wsRef.current?.broadcast('canvas:timer', nextPayload)
       } catch (error) {
         onSyncError?.(error instanceof Error ? error.message : 'Kunne ikke starte timer')
       } finally {
@@ -112,6 +126,7 @@ const useCanvasTimerSync = ({ enabled, projectId, dashboardId, onSyncError }: Us
       setIsSavingTimer(true)
       await clearCanvasTimer(projectId, dashboardId)
       setTimerPayload(null)
+      wsRef.current?.broadcast('canvas:timer', null)
     } catch (error) {
       onSyncError?.(error instanceof Error ? error.message : 'Kunne ikke stoppe timer')
     } finally {
@@ -125,12 +140,11 @@ const useCanvasTimerSync = ({ enabled, projectId, dashboardId, onSyncError }: Us
       setIsSavingTimer(true)
       const nextPayload = await pauseCanvasTimer(projectId, dashboardId)
       setTimerPayload(nextPayload)
-    } catch (error) {
-      onSyncError?.(error instanceof Error ? error.message : 'Kunne ikke pause nedtelling')
+      wsRef.current?.broadcast('canvas:timer', nextPayload)
     } finally {
       setIsSavingTimer(false)
     }
-  }, [dashboardId, enabled, onSyncError, projectId])
+  }, [dashboardId, enabled, projectId])
 
   const resumeTimer = useCallback(async () => {
     if (!enabled || projectId === null || dashboardId === null) return
@@ -138,6 +152,7 @@ const useCanvasTimerSync = ({ enabled, projectId, dashboardId, onSyncError }: Us
       setIsSavingTimer(true)
       const nextPayload = await resumeCanvasTimer(projectId, dashboardId)
       setTimerPayload(nextPayload)
+      wsRef.current?.broadcast('canvas:timer', nextPayload)
     } catch (error) {
       onSyncError?.(error instanceof Error ? error.message : 'Kunne ikke fortsette nedtelling')
     } finally {
@@ -154,6 +169,7 @@ const useCanvasTimerSync = ({ enabled, projectId, dashboardId, onSyncError }: Us
         setIsSavingTimer(true)
         const nextPayload = await adjustCanvasTimer(projectId, dashboardId, deltaSeconds)
         setTimerPayload(nextPayload)
+        wsRef.current?.broadcast('canvas:timer', nextPayload)
       } catch (error) {
         onSyncError?.(error instanceof Error ? error.message : 'Kunne ikke oppdatere nedtelling')
       } finally {

--- a/src/client/features/canvas/hooks/useCanvasWebSocket.ts
+++ b/src/client/features/canvas/hooks/useCanvasWebSocket.ts
@@ -1,0 +1,240 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+const WS_PATH = '/api/canvas/ws'
+const PING_INTERVAL_MS = 25_000
+const BACKOFF_STEPS_MS = [1_000, 2_000, 4_000, 8_000, 30_000]
+
+type EventHandler = (payload: unknown) => void
+
+export type CanvasWebSocketHandle = {
+  subscribe: (event: string, handler: EventHandler) => () => void
+  broadcast: (event: string, payload: unknown) => void
+  isConnected: boolean
+}
+
+type UseCanvasWebSocketParams = {
+  enabled: boolean
+  projectId: number | null
+  dashboardId: number | null
+}
+
+type IncomingMessage = {
+  event?: string
+  payload?: unknown
+}
+
+const buildWsUrl = (): string => {
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${protocol}//${window.location.host}${WS_PATH}`
+}
+
+const useCanvasWebSocket = ({ enabled, projectId, dashboardId }: UseCanvasWebSocketParams): CanvasWebSocketHandle => {
+  const [isConnected, setIsConnected] = useState(false)
+
+  const wsRef = useRef<WebSocket | null>(null)
+  const handlersRef = useRef<Map<string, Set<EventHandler>>>(new Map())
+  const reconnectTimerRef = useRef<number | null>(null)
+  const pingTimerRef = useRef<number | null>(null)
+  const backoffIndexRef = useRef(0)
+  const destroyedRef = useRef(false)
+
+  const projectIdRef = useRef(projectId)
+  const dashboardIdRef = useRef(dashboardId)
+  useEffect(() => {
+    projectIdRef.current = projectId
+    dashboardIdRef.current = dashboardId
+  }, [projectId, dashboardId])
+
+  const scheduleReconnectRef = useRef<() => void>(() => undefined)
+  const connectRef = useRef<() => void>(() => undefined)
+
+  useEffect(() => {
+    if (!enabled || projectId === null || dashboardId === null) return
+
+    destroyedRef.current = false
+
+    const clearPing = () => {
+      if (pingTimerRef.current !== null) {
+        window.clearInterval(pingTimerRef.current)
+        pingTimerRef.current = null
+      }
+    }
+
+    const clearReconnect = () => {
+      if (reconnectTimerRef.current !== null) {
+        window.clearTimeout(reconnectTimerRef.current)
+        reconnectTimerRef.current = null
+      }
+    }
+
+    const startPing = (ws: WebSocket) => {
+      clearPing()
+      pingTimerRef.current = window.setInterval(() => {
+        if (ws.readyState === WebSocket.OPEN) {
+          try {
+            ws.send(JSON.stringify({ type: 'ping' }))
+          } catch {
+            /* ignored */
+          }
+        }
+      }, PING_INTERVAL_MS)
+    }
+
+    const connect = () => {
+      if (destroyedRef.current) return
+
+      if (wsRef.current) {
+        try {
+          wsRef.current.onopen = null
+          wsRef.current.onmessage = null
+          wsRef.current.onclose = null
+          wsRef.current.onerror = null
+          wsRef.current.close()
+        } catch {
+          /* ignored */
+        }
+        wsRef.current = null
+      }
+
+      let ws: WebSocket
+      try {
+        ws = new WebSocket(buildWsUrl())
+      } catch {
+        scheduleReconnectRef.current()
+        return
+      }
+
+      wsRef.current = ws
+
+      ws.onopen = () => {
+        if (destroyedRef.current) {
+          ws.close()
+          return
+        }
+        backoffIndexRef.current = 0
+        setIsConnected(true)
+        try {
+          ws.send(
+            JSON.stringify({
+              type: 'join',
+              projectId: projectIdRef.current,
+              dashboardId: dashboardIdRef.current,
+            }),
+          )
+        } catch {
+          /* ignored */
+        }
+        startPing(ws)
+      }
+
+      ws.onmessage = (event: MessageEvent<unknown>) => {
+        if (destroyedRef.current) return
+        let parsed: IncomingMessage
+        try {
+          parsed = JSON.parse(typeof event.data === 'string' ? event.data : '') as IncomingMessage
+        } catch {
+          return
+        }
+        const { event: eventName, payload } = parsed
+        if (typeof eventName !== 'string') return
+        const handlers = handlersRef.current.get(eventName)
+        if (!handlers) return
+        for (const handler of handlers) {
+          try {
+            handler(payload ?? null)
+          } catch {
+            /* ignored */
+          }
+        }
+      }
+
+      ws.onclose = () => {
+        if (destroyedRef.current) return
+        clearPing()
+        setIsConnected(false)
+        wsRef.current = null
+        scheduleReconnectRef.current()
+      }
+
+      ws.onerror = () => {
+        // onclose fires after onerror — reconnect handled there
+        clearPing()
+        setIsConnected(false)
+      }
+    }
+
+    const scheduleReconnect = () => {
+      if (destroyedRef.current) return
+      clearReconnect()
+      const delayMs = BACKOFF_STEPS_MS[Math.min(backoffIndexRef.current, BACKOFF_STEPS_MS.length - 1)]
+      backoffIndexRef.current = Math.min(backoffIndexRef.current + 1, BACKOFF_STEPS_MS.length - 1)
+      reconnectTimerRef.current = window.setTimeout(() => {
+        connectRef.current()
+      }, delayMs)
+    }
+
+    connectRef.current = connect
+    scheduleReconnectRef.current = scheduleReconnect
+
+    connect()
+
+    return () => {
+      destroyedRef.current = true
+      clearPing()
+      clearReconnect()
+      setIsConnected(false)
+      if (wsRef.current) {
+        try {
+          wsRef.current.onopen = null
+          wsRef.current.onmessage = null
+          wsRef.current.onclose = null
+          wsRef.current.onerror = null
+          wsRef.current.close()
+        } catch {
+          /* ignored */
+        }
+        wsRef.current = null
+      }
+    }
+  }, [enabled, projectId, dashboardId])
+
+  const subscribe = useCallback((event: string, handler: EventHandler): (() => void) => {
+    let handlers = handlersRef.current.get(event)
+    if (!handlers) {
+      handlers = new Set()
+      handlersRef.current.set(event, handlers)
+    }
+    handlers.add(handler)
+    return () => {
+      const set = handlersRef.current.get(event)
+      if (set) {
+        set.delete(handler)
+        if (set.size === 0) {
+          handlersRef.current.delete(event)
+        }
+      }
+    }
+  }, [])
+
+  const broadcast = useCallback((event: string, payload: unknown): void => {
+    const ws = wsRef.current
+    if (!ws || ws.readyState !== WebSocket.OPEN) return
+    try {
+      ws.send(
+        JSON.stringify({
+          type: 'broadcast',
+          projectId: projectIdRef.current,
+          dashboardId: dashboardIdRef.current,
+          event,
+          payload,
+        }),
+      )
+    } catch {
+      /* ignored */
+    }
+  }, [])
+
+  return useMemo(() => ({ subscribe, broadcast, isConnected }), [subscribe, broadcast, isConnected])
+}
+
+export default useCanvasWebSocket

--- a/src/client/features/canvas/ui/Canvas.tsx
+++ b/src/client/features/canvas/ui/Canvas.tsx
@@ -76,6 +76,7 @@ import useCanvasFrameFormHandlers from '../hooks/useCanvasFrameFormHandlers.ts'
 import useCanvasPresence from '../hooks/useCanvasPresence.ts'
 import useCanvasDotVotingSync from '../hooks/useCanvasDotVotingSync.ts'
 import useCanvasTimerSync from '../hooks/useCanvasTimerSync.ts'
+import useCanvasWebSocket from '../hooks/useCanvasWebSocket.ts'
 import useCanvasInteractions, {
   type CanvasDragState,
   type CanvasResizeState,
@@ -657,11 +658,23 @@ const Canvas = () => {
 
   const canvasSyncContextEnabled =
     canPersistToDashboard && projectId !== null && dashboardId !== null && canvasInitMode === 'existing'
+
+  const canvasWebSocket = useCanvasWebSocket({
+    enabled: canvasSyncContextEnabled,
+    projectId,
+    dashboardId,
+  })
+  const canvasWebSocketRef = useRef(canvasWebSocket)
+  useEffect(() => {
+    canvasWebSocketRef.current = canvasWebSocket
+  })
+
   const { activeParticipantCount, activeOtherParticipantCount, shouldEnableBackgroundSync, participantLabels } =
     useCanvasPresence({
       enabled: canvasSyncContextEnabled,
       projectId,
       dashboardId,
+      ws: canvasWebSocket,
     })
   const shouldEnableEditLockSync = activeEditableFrameId !== null
 
@@ -682,6 +695,7 @@ const Canvas = () => {
     projectId,
     dashboardId,
     onSyncError: handleCanvasSyncError,
+    ws: canvasWebSocket,
   })
 
   const {
@@ -710,6 +724,7 @@ const Canvas = () => {
     projectId,
     dashboardId,
     onSyncError: handleCanvasSyncError,
+    ws: canvasWebSocket,
   })
   const isDotVotingActive = Boolean(dotVotingSessionPayload) && dotVotingSessionPayload?.status !== 'ended'
   const isCanvasReadOnly = isCanvasLocked && !isLockedModeEditing
@@ -1214,12 +1229,14 @@ const Canvas = () => {
           name: CANVAS_QUERY_NAME,
           sqlText: serialized,
         })
-        return {
+        const persistedFrame = {
           ...frame,
           categoryId,
           graphId: createdGraph.id,
           queryId: createdQuery.id,
         }
+        canvasWebSocketRef.current.broadcast('canvas:frame', persistedFrame)
+        return persistedFrame
       }
 
       if (frame.queryId) {
@@ -1227,6 +1244,7 @@ const Canvas = () => {
           name: CANVAS_QUERY_NAME,
           sqlText: serialized,
         })
+        canvasWebSocketRef.current.broadcast('canvas:frame', frame)
         return frame
       }
 
@@ -1234,11 +1252,13 @@ const Canvas = () => {
         name: CANVAS_QUERY_NAME,
         sqlText: serialized,
       })
-      return {
+      const persistedFrame = {
         ...frame,
         categoryId,
         queryId: createdQuery.id,
       }
+      canvasWebSocketRef.current.broadcast('canvas:frame', persistedFrame)
+      return persistedFrame
     },
     [canPersistToDashboard, projectId, dashboardId, ensureCanvasCategory],
   )
@@ -1362,6 +1382,7 @@ const Canvas = () => {
     setConnections,
     setSyncError,
     onBeforeApplyRemoteData: markRemoteCanvasFramesApplied,
+    ws: canvasWebSocket,
   })
 
   const {
@@ -1377,6 +1398,7 @@ const Canvas = () => {
       setActiveEditableFrameId(null)
       setSyncError('Kortet blir redigert av en kollega akkurat nå.')
     },
+    ws: canvasWebSocket,
   })
 
   useEffect(() => {

--- a/src/server/websocket/canvasWebSocketServer.js
+++ b/src/server/websocket/canvasWebSocketServer.js
@@ -1,0 +1,137 @@
+import { WebSocketServer } from 'ws'
+import { getMockUser, loadOasis, resolveUserFromToken } from '../middleware/authUtils.js'
+
+const WS_PATH = '/api/canvas/ws'
+
+async function authenticateUpgradeRequest(req) {
+  const mockUser = getMockUser()
+  if (mockUser) return { ok: true, user: mockUser }
+
+  const { oasis } = await loadOasis()
+  if (!oasis) {
+    return { ok: true, user: { navIdent: 'LOCAL_DEV' } }
+  }
+
+  return resolveUserFromToken(req, oasis)
+}
+
+export function createCanvasWebSocketServer(server) {
+  const rooms = new Map()
+
+  const wss = new WebSocketServer({ noServer: true })
+
+  server.on('upgrade', async (req, socket, head) => {
+    const url = new URL(req.url, `http://${req.headers.host}`)
+    if (url.pathname !== WS_PATH) return
+
+    try {
+      const authResult = await authenticateUpgradeRequest(req)
+      if (!authResult.ok) {
+        console.log('[Canvas WS] Rejected unauthenticated upgrade')
+        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
+        socket.destroy()
+        return
+      }
+
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        ws._user = authResult.user
+        wss.emit('connection', ws, req)
+      })
+    } catch (err) {
+      console.error('[Canvas WS] Error during upgrade auth:', err)
+      socket.write('HTTP/1.1 500 Internal Server Error\r\n\r\n')
+      socket.destroy()
+    }
+  })
+
+  wss.on('connection', (ws) => {
+    let currentRoomKey = null
+
+    const leaveRoom = () => {
+      if (currentRoomKey) {
+        const room = rooms.get(currentRoomKey)
+        if (room) {
+          room.delete(ws)
+          if (room.size === 0) rooms.delete(currentRoomKey)
+          console.log(
+            `[Canvas WS] ${ws._user?.navIdent ?? 'unknown'} left room ${currentRoomKey} (${rooms.get(currentRoomKey)?.size ?? 0} remaining)`,
+          )
+        }
+        currentRoomKey = null
+      }
+    }
+
+    const send = (data) => {
+      if (ws.readyState === ws.OPEN) {
+        ws.send(JSON.stringify(data))
+      }
+    }
+
+    ws.on('message', (raw) => {
+      let msg
+      try {
+        msg = JSON.parse(raw.toString())
+      } catch {
+        send({ type: 'error', message: 'Invalid JSON' })
+        return
+      }
+
+      if (msg.type === 'ping') {
+        send({ type: 'pong' })
+        return
+      }
+
+      if (msg.type === 'join') {
+        const { projectId, dashboardId } = msg
+        if (!Number.isFinite(Number(projectId)) || !Number.isFinite(Number(dashboardId))) {
+          send({ type: 'error', message: 'join requires numeric projectId and dashboardId' })
+          return
+        }
+
+        leaveRoom()
+        currentRoomKey = `${projectId}:${dashboardId}`
+        if (!rooms.has(currentRoomKey)) rooms.set(currentRoomKey, new Set())
+        rooms.get(currentRoomKey).add(ws)
+
+        console.log(
+          `[Canvas WS] ${ws._user?.navIdent ?? 'unknown'} joined room ${currentRoomKey} (${rooms.get(currentRoomKey).size} total)`,
+        )
+        return
+      }
+
+      if (msg.type === 'broadcast') {
+        const { projectId, dashboardId, event, payload } = msg
+        if (!projectId || !dashboardId || !event) {
+          send({ type: 'error', message: 'broadcast requires projectId, dashboardId, event' })
+          return
+        }
+
+        const roomKey = `${projectId}:${dashboardId}`
+        const room = rooms.get(roomKey)
+        if (!room) return
+
+        const outgoing = JSON.stringify({ type: 'event', event, payload })
+        for (const client of room) {
+          if (client.readyState === client.OPEN) {
+            client.send(outgoing)
+          }
+        }
+        return
+      }
+
+      send({ type: 'error', message: `Unknown message type: ${msg.type}` })
+    })
+
+    ws.on('close', () => {
+      leaveRoom()
+    })
+
+    ws.on('error', (err) => {
+      console.error('[Canvas WS] Socket error:', err.message)
+      leaveRoom()
+    })
+  })
+
+  console.log(`[Canvas WS] WebSocket server ready at ${WS_PATH}`)
+  return wss
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
+      '/api/canvas/ws': {
+        target: 'ws://localhost:8081',
+        changeOrigin: true,
+        ws: true,
+      },
       '/api': {
         target: 'http://localhost:8081',
         changeOrigin: true,


### PR DESCRIPTION
## Summary

- **BFF WebSocket server** (`src/server/websocket/canvasWebSocketServer.js`): room-based, auth-gated WS server mounted at `/api/canvas/ws`. Each canvas session gets its own room; only authenticated users (via existing session middleware) can join. Server handles `join`, `leave`, and all canvas event types.
- **`server.js`**: switched from `app.listen()` to `http.createServer(app)` so the WS server can share the same HTTP port.
- **`useCanvasWebSocket` hook** (`src/client/features/canvas/hooks/useCanvasWebSocket.ts`): manages the WS connection lifecycle — exponential backoff reconnect, ping/pong keepalive, typed message dispatch, and a stable `sendMessage` ref.
- **Canvas.tsx**: instantiates `useCanvasWebSocket` and passes the `ws` instance + `isConnected` flag down to all sync hooks.
- **5 sync hooks updated** (`useCanvasPresence`, `useCanvasBackgroundSync`, `useCanvasTimerSync`, `useCanvasDotVotingSync`, `useCanvasEditLocks`): each hook now accepts an optional `ws` prop. When `isConnected` is true, outbound mutations are sent over WS instead of HTTP; inbound WS messages are handled directly. Polling is disabled while WS is connected, falling back automatically if the connection drops.
- **`vite.config.ts`**: added WS proxy rule for `/api/canvas/ws` so the dev server correctly upgrades the connection.