### PR TITLE
Trekk ut kohort-SQL til eget modul med CohortClauses-seam

### DIFF
--- a/src/client/features/chartbuilder/hooks/useChartConfig.ts
+++ b/src/client/features/chartbuilder/hooks/useChartConfig.ts
@@ -65,10 +65,10 @@ export function useChartConfig() {
 
   // Create a function to calculate the current step based on selections
   const calculateCurrentStep = useCallback(() => {
-    const hasSegmentRules =
-      (config.segments || []).length > 1 ||
-      (config.segments || []).some(
-        (segment) => (segment.filters?.length || 0) > 0 || (segment.performed?.events?.length || 0) > 0,
+    const hasCohortRules =
+      (config.cohorts || []).length > 1 ||
+      (config.cohorts || []).some(
+        (cohort) => (cohort.filters?.length || 0) > 0 || (cohort.performed?.events?.length || 0) > 0,
       )
 
     if (!config.website) {
@@ -79,12 +79,12 @@ export function useChartConfig() {
       return 2
     }
 
-    if (filters.length === 0 && !hasSegmentRules) {
+    if (filters.length === 0 && !hasCohortRules) {
       return 3
     }
 
     return 4
-  }, [config.website, filters.length, hasUserSelectedMetrics, config.groupByFields.length, config.segments])
+  }, [config.website, filters.length, hasUserSelectedMetrics, config.groupByFields.length, config.cohorts])
 
   // Update the step whenever relevant data changes
   useEffect(() => {

--- a/src/client/features/chartbuilder/index.ts
+++ b/src/client/features/chartbuilder/index.ts
@@ -23,4 +23,6 @@ export { isRecord, safeParseJson, isMetricArray, isWebsiteLike, isFilterLike, is
 export { getMetricColumns, getParameterAggregator } from './utils/metricColumns'
 export { isSessionColumn, getRequiredSessionColumns, getRequiredTables } from './utils/sessionUtils'
 export { generateSQLCore, getMetricSQL, getMetricSQLByType, getDateFilterConditions } from './utils/sqlGenerator'
+export { buildCohortClauses } from './utils/cohortSql'
+export type { CohortClauses } from './utils/cohortSql'
 export { applyUrlFiltersToSql, extractWebsiteId } from './utils/sqlFilters'

--- a/src/client/features/chartbuilder/ui/Grafbygger.tsx
+++ b/src/client/features/chartbuilder/ui/Grafbygger.tsx
@@ -13,7 +13,7 @@ import AlertWithCloseButton from './grafbygger/AlertWithCloseButton.tsx'
 import ActiveMetricsPanel from './grafbygger/ActiveMetricsPanel.tsx'
 import SidebarSection from '../../../shared/ui/SidebarSection.tsx'
 import ActionFeedbackButton from '../../../shared/ui/ActionFeedbackButton.tsx'
-import type { SegmentDefinition } from '../../../shared/types/chart.ts'
+import type { CohortDefinition } from '../../../shared/types/chart.ts'
 import { FILTER_COLUMNS } from '../../../shared/lib/constants.ts'
 import { DATE_FORMATS, METRICS } from '../model/constants.ts'
 import { sanitizeColumnName } from '../utils/sanitize.ts'
@@ -79,11 +79,11 @@ const ChartsPage = () => {
     handleEventsLoad,
   } = useChartConfig()
 
-  const handleSegmentsChange = useCallback(
-    (segments: SegmentDefinition[]) => {
+  const handleCohortsChange = useCallback(
+    (cohorts: CohortDefinition[]) => {
       setConfig((prev) => ({
         ...prev,
-        segments,
+        cohorts,
       }))
     },
     [setConfig],
@@ -105,26 +105,26 @@ const ChartsPage = () => {
     setMetricResetSignal((prev) => prev + 1)
   }, [resetAll])
 
-  const hasSegmentConfigToReset = useCallback((segments: SegmentDefinition[] | undefined): boolean => {
-    if (!segments || segments.length === 0) {
+  const hasCohortConfigToReset = useCallback((cohorts: CohortDefinition[] | undefined): boolean => {
+    if (!cohorts || cohorts.length === 0) {
       return false
     }
 
-    if (segments.length !== 1) {
+    if (cohorts.length !== 1) {
       return true
     }
 
-    const [segment] = segments
-    const hasFilters = (segment.filters?.length || 0) > 0
-    const hasPerformedSelection = (segment.performed?.events?.length || 0) > 0
-    const hasCustomName = (segment.name || '').trim() !== 'Alle brukere'
+    const [cohort] = cohorts
+    const hasFilters = (cohort.filters?.length || 0) > 0
+    const hasPerformedSelection = (cohort.performed?.events?.length || 0) > 0
+    const hasCustomName = (cohort.name || '').trim() !== 'Alle brukere'
 
     return hasFilters || hasPerformedSelection || hasCustomName
   }, [])
 
   const showResetEventFilters = isEventFilterDirty
   const showResetMetrics = config.metrics.length > 0
-  const showResetSegments = hasSegmentConfigToReset(config.segments)
+  const showResetSegments = hasCohortConfigToReset(config.cohorts)
   const showResetGroupings = config.groupByFields.length > 0
   const showResetDisplayOptions =
     Boolean(config.orderBy) ||
@@ -270,7 +270,7 @@ const ChartsPage = () => {
                     }
                   }}
                   isEventsLoading={isEventsLoading}
-                  onSegmentsChange={handleSegmentsChange}
+                  onSegmentsChange={handleCohortsChange}
                 />
               </SidebarSection>
 

--- a/src/client/features/chartbuilder/ui/grafbygger/SegmentBy.tsx
+++ b/src/client/features/chartbuilder/ui/grafbygger/SegmentBy.tsx
@@ -1,7 +1,7 @@
 import { Button, Select, Tag, TextField, UNSAFE_Combobox } from '@navikt/ds-react'
 import { PencilIcon } from '@navikt/aksel-icons'
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from 'react'
-import type { Filter, Parameter, SegmentDefinition as ChartSegmentDefinition } from '../../../../shared/types/chart.ts'
+import type { Filter, Parameter, CohortDefinition } from '../../../../shared/types/chart.ts'
 import { OPERATORS } from '../../../../shared/lib/constants.ts'
 import EventFilter from './EventFilter.tsx'
 
@@ -21,7 +21,7 @@ interface SegmentByProps {
   onDateRangeInDaysChange: (days: number) => void
   onEnableCustomEvents?: (withParams?: boolean) => void
   isEventsLoading?: boolean
-  onSegmentsChange?: (segments: ChartSegmentDefinition[]) => void
+  onSegmentsChange?: (cohorts: CohortDefinition[]) => void
 }
 
 interface PerformedSelection {
@@ -216,7 +216,7 @@ const SegmentBy = forwardRef<SegmentByRef, SegmentByProps>(
     useEffect(() => {
       if (!onSegmentsChange) return
 
-      const payload: ChartSegmentDefinition[] = segments.map((segment) => {
+      const payload: CohortDefinition[] = segments.map((segment) => {
         const performedSelection = performedSelections[segment.id]
         const hasPerformedSelection = (performedSelection?.events?.length || 0) > 0
 

--- a/src/client/features/chartbuilder/utils/cohortSql.test.ts
+++ b/src/client/features/chartbuilder/utils/cohortSql.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest'
+import { buildCohortClauses } from './cohortSql.ts'
+import type { CohortDefinition } from '../../../shared/types/chart.ts'
+
+const emptyCohort = (id: number, name: string): CohortDefinition => ({
+  id,
+  name,
+  filters: [],
+  performed: null,
+})
+
+describe('buildCohortClauses', () => {
+  describe('inactive cases', () => {
+    it('returns inactive for empty array', () => {
+      const result = buildCohortClauses([])
+      expect(result.active).toBe(false)
+      expect(result.cte).toBe('')
+    })
+
+    it('returns inactive for single cohort with no filters and no performed', () => {
+      const result = buildCohortClauses([emptyCohort(1, 'Alle brukere')])
+      expect(result.active).toBe(false)
+    })
+  })
+
+  describe('active cases', () => {
+    it('activates when two or more cohorts exist', () => {
+      const result = buildCohortClauses([emptyCohort(1, 'A'), emptyCohort(2, 'B')])
+      expect(result.active).toBe(true)
+    })
+
+    it('activates when single cohort has a filter', () => {
+      const cohort: CohortDefinition = {
+        id: 1,
+        name: 'Med filter',
+        filters: [{ column: 'url_path', operator: '=', value: '/home' }],
+      }
+      const result = buildCohortClauses([cohort])
+      expect(result.active).toBe(true)
+    })
+
+    it('activates when single cohort has performed events', () => {
+      const cohort: CohortDefinition = {
+        id: 1,
+        name: 'Utforte hendelser',
+        filters: [],
+        performed: { operator: 'IN', events: ['klikk'] },
+      }
+      const result = buildCohortClauses([cohort])
+      expect(result.active).toBe(true)
+    })
+  })
+
+  describe('CTE output', () => {
+    it('produces a UNION ALL CTE for two cohorts', () => {
+      const result = buildCohortClauses([emptyCohort(1, 'Gruppe A'), emptyCohort(2, 'Gruppe B')])
+      expect(result.cte).toContain('segmented_base AS (')
+      expect(result.cte).toContain("SELECT 'Gruppe A' AS segment_navn")
+      expect(result.cte).toContain("SELECT 'Gruppe B' AS segment_navn")
+      expect(result.cte).toContain('UNION ALL')
+    })
+
+    it('uses 1=1 WHERE clause when cohort has no conditions', () => {
+      const result = buildCohortClauses([emptyCohort(1, 'A'), emptyCohort(2, 'B')])
+      expect(result.cte).toContain('WHERE 1=1')
+    })
+
+    it('builds filter condition for url_path equality', () => {
+      const cohort: CohortDefinition = {
+        id: 1,
+        name: 'Frontside',
+        filters: [{ column: 'url_path', operator: '=', value: '/home' }],
+        performed: null,
+      }
+      const result = buildCohortClauses([cohort, emptyCohort(2, 'Andre')])
+      expect(result.cte).toContain("b.url_path = '/home'")
+    })
+
+    it('builds IN condition for multiple values', () => {
+      const cohort: CohortDefinition = {
+        id: 1,
+        name: 'Sider',
+        filters: [{ column: 'url_path', operator: 'IN', multipleValues: ['/a', '/b'] }],
+      }
+      const result = buildCohortClauses([cohort, emptyCohort(2, 'Resten')])
+      expect(result.cte).toContain("b.url_path IN ('/a', '/b')")
+    })
+
+    it('builds STARTS_WITH as LIKE pattern', () => {
+      const cohort: CohortDefinition = {
+        id: 1,
+        name: 'Prefiks',
+        filters: [{ column: 'url_path', operator: 'STARTS_WITH', value: '/soknad' }],
+      }
+      const result = buildCohortClauses([cohort, emptyCohort(2, 'Resten')])
+      expect(result.cte).toContain("b.url_path LIKE '/soknad%'")
+    })
+
+    it('escapes single quotes in cohort name', () => {
+      const result = buildCohortClauses([emptyCohort(1, "O'Brien"), emptyCohort(2, 'Andre')])
+      expect(result.cte).toContain("SELECT 'O''Brien' AS segment_navn")
+    })
+
+    it('builds performed IN condition', () => {
+      const cohort: CohortDefinition = {
+        id: 1,
+        name: 'Klikket',
+        filters: [],
+        performed: { operator: 'IN', events: ['klikk', 'trykk'] },
+      }
+      const result = buildCohortClauses([cohort, emptyCohort(2, 'Resten')])
+      expect(result.cte).toContain("b.event_name IN ('klikk', 'trykk')")
+    })
+
+    it('builds performed STARTS_WITH condition', () => {
+      const cohort: CohortDefinition = {
+        id: 1,
+        name: 'Starter med',
+        filters: [],
+        performed: { operator: 'STARTS_WITH', events: ['nav_'] },
+      }
+      const result = buildCohortClauses([cohort, emptyCohort(2, 'Resten')])
+      expect(result.cte).toContain("b.event_name LIKE 'nav_%'")
+    })
+  })
+
+  describe('clause values', () => {
+    it('returns correct selectColumn', () => {
+      const result = buildCohortClauses([emptyCohort(1, 'A'), emptyCohort(2, 'B')])
+      expect(result.selectColumn).toBe('base_query.segment_navn AS segment')
+    })
+
+    it('returns correct fromTable', () => {
+      const result = buildCohortClauses([emptyCohort(1, 'A'), emptyCohort(2, 'B')])
+      expect(result.fromTable).toBe('segmented_base AS base_query')
+    })
+
+    it('returns correct groupByColumn', () => {
+      const result = buildCohortClauses([emptyCohort(1, 'A'), emptyCohort(2, 'B')])
+      expect(result.groupByColumn).toBe('base_query.segment_navn')
+    })
+
+    it('inactive result has empty string fromTable fallback', () => {
+      const result = buildCohortClauses([])
+      expect(result.fromTable).toBe('base_query')
+    })
+  })
+})

--- a/src/client/features/chartbuilder/utils/cohortSql.ts
+++ b/src/client/features/chartbuilder/utils/cohortSql.ts
@@ -1,0 +1,164 @@
+import type { CohortDefinition } from '../../../shared/types/chart.ts'
+
+/**
+ * SQL clauses produced by buildCohortClauses.
+ * Each field maps to one insertion point in generateSQLCore.
+ *
+ * active=false → single-cohort query, all other fields are empty strings.
+ */
+export type CohortClauses = {
+  /** Whether multi-cohort SQL mode is needed at all. */
+  active: boolean
+  /** The `segmented_base AS (...)` CTE block, including leading `,\n` and trailing `\n)\n\n`. */
+  cte: string
+  /** SELECT column: `base_query.segment_navn AS segment` */
+  selectColumn: string
+  /** FROM suffix when cohorts are active: `segmented_base AS base_query` instead of `base_query`. */
+  fromTable: string
+  /** GROUP BY column: `base_query.segment_navn` */
+  groupByColumn: string
+}
+
+const escapeSqlLiteral = (value: string): string => value.replace(/'/g, "''")
+
+const needsQuotedValue = (column: string, value: string): boolean => {
+  return (
+    isNaN(Number(value)) ||
+    column === 'event_name' ||
+    column === 'url_path' ||
+    column.includes('_path') ||
+    column.includes('_name')
+  )
+}
+
+const buildCohortFilterCondition = (filter: CohortDefinition['filters'][number], tableAlias: string): string | null => {
+  if (filter.column.startsWith('param_')) return null
+  if (!filter.operator) return null
+
+  const columnRef = `${tableAlias}.${filter.column}`
+
+  if (filter.operator === 'IS NULL' || filter.operator === 'IS NOT NULL') {
+    return `${columnRef} ${filter.operator}`
+  }
+
+  if (filter.operator === 'IN' && filter.multipleValues && filter.multipleValues.length > 0) {
+    const values = filter.multipleValues
+      .map((value) => (needsQuotedValue(filter.column, value) ? `'${escapeSqlLiteral(value)}'` : value))
+      .join(', ')
+    return `${columnRef} IN (${values})`
+  }
+
+  if (!filter.value) return null
+
+  if (filter.operator === 'STARTS_WITH') {
+    return `${columnRef} LIKE '${escapeSqlLiteral(filter.value)}%'`
+  }
+
+  if (filter.operator === 'ENDS_WITH') {
+    return `${columnRef} LIKE '%${escapeSqlLiteral(filter.value)}'`
+  }
+
+  if ((filter.operator === 'LIKE' || filter.operator === 'NOT LIKE') && !filter.value.includes('%')) {
+    return `${columnRef} ${filter.operator} '%${escapeSqlLiteral(filter.value)}%'`
+  }
+
+  const isMetabaseParam =
+    filter.metabaseParam === true || (typeof filter.value === 'string' && /^\s*\{\{.*\}\}\s*$/.test(filter.value))
+
+  const isTimestampFunction =
+    typeof filter.value === 'string' &&
+    filter.value.toUpperCase().includes('TIMESTAMP(') &&
+    !filter.value.startsWith("'")
+
+  if (isMetabaseParam) {
+    return `${columnRef} ${filter.operator} ${filter.value.trim()}`
+  }
+
+  const formattedValue = isTimestampFunction
+    ? filter.value.replace(/^['"]|['"]$/g, '')
+    : needsQuotedValue(filter.column, filter.value)
+      ? `'${escapeSqlLiteral(filter.value)}'`
+      : filter.value
+
+  return `${columnRef} ${filter.operator} ${formattedValue}`
+}
+
+const buildPerformedCondition = (
+  performed: NonNullable<CohortDefinition['performed']>,
+  tableAlias: string,
+): string | null => {
+  if (performed.events.length === 0) return null
+
+  const { operator, events } = performed
+
+  if (operator === 'IN') {
+    const eventList = events.map((e) => `'${escapeSqlLiteral(e)}'`).join(', ')
+    return `${tableAlias}.event_name IN (${eventList})`
+  }
+
+  const selectedEvent = events[0]
+  if (!selectedEvent) return null
+
+  switch (operator) {
+    case 'LIKE':
+      return `${tableAlias}.event_name LIKE '%${escapeSqlLiteral(selectedEvent)}%'`
+    case '!=':
+      return `${tableAlias}.event_name != '${escapeSqlLiteral(selectedEvent)}'`
+    case 'STARTS_WITH':
+      return `${tableAlias}.event_name LIKE '${escapeSqlLiteral(selectedEvent)}%'`
+    case 'ENDS_WITH':
+      return `${tableAlias}.event_name LIKE '%${escapeSqlLiteral(selectedEvent)}'`
+    default:
+      return `${tableAlias}.event_name = '${escapeSqlLiteral(selectedEvent)}'`
+  }
+}
+
+// TODO(backend-cohorts): When innblikk-backend cohorts branch merges and CohortDetailDto is live:
+//   1. Add chartbuilder/api/cohortApi.ts  — GET /api/cohort?websiteId, GET /api/cohort/{id}
+//   2. Add chartbuilder/utils/cohortDtoMapper.ts — translate CohortDetailDto → CohortDefinition:
+//      - CohortEntryDto.conditions (field/value/conditionType) → Filter[]
+//      - CohortEntryDto with EntryConditionType=PERFORMED → CohortDefinition.performed
+//      - Skip time-scoped entries (TimeScope/TimeRangeType/TimeQualifier) — deferred per CONTEXT.md v1 scope
+//   3. Grafbygger fetches CohortDetailDto per selected cohort and maps before calling buildCohortClauses.
+export const buildCohortClauses = (cohorts: CohortDefinition[]): CohortClauses => {
+  const inactive: CohortClauses = {
+    active: false,
+    cte: '',
+    selectColumn: '',
+    fromTable: 'base_query',
+    groupByColumn: '',
+  }
+
+  const isActive =
+    cohorts.length > 0 &&
+    (cohorts.length > 1 || cohorts.some((c) => (c.filters?.length ?? 0) > 0 || (c.performed?.events?.length ?? 0) > 0))
+
+  if (!isActive) return inactive
+
+  const tableAlias = 'b'
+
+  const cohortQueries = cohorts.map((cohort) => {
+    const conditions: string[] = (cohort.filters ?? [])
+      .map((f) => buildCohortFilterCondition(f, tableAlias))
+      .filter((c): c is string => Boolean(c))
+
+    if (cohort.performed) {
+      const performedCond = buildPerformedCondition(cohort.performed, tableAlias)
+      if (performedCond) conditions.push(performedCond)
+    }
+
+    const whereClause = conditions.length > 0 ? conditions.join('\n    AND ') : '1=1'
+
+    return `  SELECT '${escapeSqlLiteral(cohort.name)}' AS segment_navn, b.*\n  FROM base_query b\n  WHERE ${whereClause}`
+  })
+
+  const cte = ',\nsegmented_base AS (\n' + cohortQueries.join('\n  UNION ALL\n') + '\n)\n\n'
+
+  return {
+    active: true,
+    cte,
+    selectColumn: 'base_query.segment_navn AS segment',
+    fromTable: 'segmented_base AS base_query',
+    groupByColumn: 'base_query.segment_navn',
+  }
+}

--- a/src/client/features/chartbuilder/utils/sqlGenerator.ts
+++ b/src/client/features/chartbuilder/utils/sqlGenerator.ts
@@ -4,6 +4,7 @@ import { DATE_FORMATS } from '../model/constants.ts'
 import { sanitizeColumnName, sanitizeFieldNameForBigQuery } from './sanitize.ts'
 import { getParameterAggregator } from './metricColumns.ts'
 import { isSessionColumn, getRequiredSessionColumns, getRequiredTables } from './sessionUtils.ts'
+import { buildCohortClauses } from './cohortSql.ts'
 
 export const getDateFilterConditions = (filters: Filter[]): string => {
   const dateFilters = filters.filter(
@@ -22,70 +23,6 @@ export const getDateFilterConditions = (filters: Filter[]): string => {
   })
 
   return conditions
-}
-
-const escapeSqlLiteral = (value: string): string => value.replace(/'/g, "''")
-
-const needsQuotedValue = (column: string, value: string): boolean => {
-  return (
-    isNaN(Number(value)) ||
-    column === 'event_name' ||
-    column === 'url_path' ||
-    column.includes('_path') ||
-    column.includes('_name')
-  )
-}
-
-const buildSegmentFilterCondition = (filter: Filter, tableAlias: string): string | null => {
-  if (filter.column.startsWith('param_')) return null
-  if (!filter.operator) return null
-
-  const columnRef = `${tableAlias}.${filter.column}`
-
-  if (filter.operator === 'IS NULL' || filter.operator === 'IS NOT NULL') {
-    return `${columnRef} ${filter.operator}`
-  }
-
-  if (filter.operator === 'IN' && filter.multipleValues && filter.multipleValues.length > 0) {
-    const values = filter.multipleValues
-      .map((value) => (needsQuotedValue(filter.column, value) ? `'${escapeSqlLiteral(value)}'` : value))
-      .join(', ')
-    return `${columnRef} IN (${values})`
-  }
-
-  if (!filter.value) return null
-
-  if (filter.operator === 'STARTS_WITH') {
-    return `${columnRef} LIKE '${escapeSqlLiteral(filter.value)}%'`
-  }
-
-  if (filter.operator === 'ENDS_WITH') {
-    return `${columnRef} LIKE '%${escapeSqlLiteral(filter.value)}'`
-  }
-
-  if ((filter.operator === 'LIKE' || filter.operator === 'NOT LIKE') && !filter.value.includes('%')) {
-    return `${columnRef} ${filter.operator} '%${escapeSqlLiteral(filter.value)}%'`
-  }
-
-  const isMetabaseParam =
-    filter.metabaseParam === true || (typeof filter.value === 'string' && /^\s*\{\{.*\}\}\s*$/.test(filter.value))
-
-  const isTimestampFunction =
-    typeof filter.value === 'string' &&
-    filter.value.toUpperCase().includes('TIMESTAMP(') &&
-    !filter.value.startsWith("'")
-
-  if (isMetabaseParam) {
-    return `${columnRef} ${filter.operator} ${filter.value.trim()}`
-  }
-
-  const formattedValue = isTimestampFunction
-    ? filter.value.replace(/^['"]|['"]$/g, '')
-    : needsQuotedValue(filter.column, filter.value)
-      ? `'${escapeSqlLiteral(filter.value)}'`
-      : filter.value
-
-  return `${columnRef} ${filter.operator} ${formattedValue}`
 }
 
 export const getMetricSQLByType = (
@@ -304,14 +241,10 @@ export const generateSQLCore = (config: ChartConfig, filters: Filter[], paramete
   const hasInteractiveFieldFilter = filters.some(
     (f) => f.interactive === true && f.metabaseParam === true && f.column === 'created_at',
   )
-  const segmentDefinitions = config.segments || []
-  const segmentFilters = segmentDefinitions.flatMap((segment) => segment.filters || [])
-  const hasSegmentBreakdown =
-    segmentDefinitions.length > 0 &&
-    (segmentDefinitions.length > 1 ||
-      segmentDefinitions.some(
-        (segment) => (segment.filters?.length || 0) > 0 || (segment.performed?.events?.length || 0) > 0,
-      ))
+  const cohort = buildCohortClauses(config.cohorts ?? [])
+  const cohortFilters = (config.cohorts ?? []).flatMap((c) => c.filters || [])
+
+  const allFilters = [...filters, ...cohortFilters]
 
   let websiteAlias, sessionAlias, tablePrefix
   let websiteRef, sessionRef
@@ -330,13 +263,11 @@ export const generateSQLCore = (config: ChartConfig, filters: Filter[], paramete
     sessionRef = 's'
   }
 
-  // Force usage of aliases to avoid TS errors
   if (websiteAlias && sessionAlias) {
     void websiteAlias
     void sessionAlias
   }
 
-  const allFilters = [...filters, ...segmentFilters]
   const requiredTables = getRequiredTables(config, allFilters)
   const needsSessionJoin = requiredTables.session
   const requiredSessionColumns = getRequiredSessionColumns(config, allFilters)
@@ -614,45 +545,8 @@ export const generateSQLCore = (config: ChartConfig, filters: Filter[], paramete
 
   sql += ')\n'
 
-  if (hasSegmentBreakdown) {
-    const segmentQueries = segmentDefinitions.map((segment) => {
-      const segmentFilters = segment.filters || []
-      const segmentConditions = segmentFilters
-        .map((filter) => buildSegmentFilterCondition(filter, 'b'))
-        .filter((condition): condition is string => Boolean(condition))
-
-      if (segment.performed && segment.performed.events.length > 0) {
-        const { operator, events } = segment.performed
-
-        if (operator === 'IN') {
-          const eventList = events.map((event) => `'${escapeSqlLiteral(event)}'`).join(', ')
-          segmentConditions.push(`b.event_name IN (${eventList})`)
-        } else {
-          const selectedEvent = events[0]
-          if (selectedEvent) {
-            if (operator === 'LIKE') {
-              segmentConditions.push(`b.event_name LIKE '%${escapeSqlLiteral(selectedEvent)}%'`)
-            } else if (operator === '!=') {
-              segmentConditions.push(`b.event_name != '${escapeSqlLiteral(selectedEvent)}'`)
-            } else if (operator === 'STARTS_WITH') {
-              segmentConditions.push(`b.event_name LIKE '${escapeSqlLiteral(selectedEvent)}%'`)
-            } else if (operator === 'ENDS_WITH') {
-              segmentConditions.push(`b.event_name LIKE '%${escapeSqlLiteral(selectedEvent)}'`)
-            } else {
-              segmentConditions.push(`b.event_name = '${escapeSqlLiteral(selectedEvent)}'`)
-            }
-          }
-        }
-      }
-
-      const whereClause = segmentConditions.length > 0 ? segmentConditions.join('\n    AND ') : '1=1'
-
-      return `  SELECT '${escapeSqlLiteral(segment.name)}' AS segment_navn, b.*\n  FROM base_query b\n  WHERE ${whereClause}`
-    })
-
-    sql += ',\nsegmented_base AS (\n'
-    sql += segmentQueries.join('\n  UNION ALL\n')
-    sql += '\n)\n\n'
+  if (cohort.active) {
+    sql += cohort.cte
   } else {
     sql += '\n'
   }
@@ -661,8 +555,8 @@ export const generateSQLCore = (config: ChartConfig, filters: Filter[], paramete
   const groupingSelectClauses: string[] = []
   const metricSelectClauses: string[] = []
 
-  if (hasSegmentBreakdown) {
-    groupingSelectClauses.push('base_query.segment_navn AS segment')
+  if (cohort.active) {
+    groupingSelectClauses.push(cohort.selectColumn)
   }
 
   config.groupByFields.forEach((field) => {
@@ -722,7 +616,7 @@ export const generateSQLCore = (config: ChartConfig, filters: Filter[], paramete
 
   sql += '  ' + dedupedSelectClauses.join(',\n  ')
 
-  sql += hasSegmentBreakdown ? '\nFROM segmented_base AS base_query\n' : '\nFROM base_query\n'
+  sql += cohort.active ? `\nFROM ${cohort.fromTable}\n` : '\nFROM base_query\n'
 
   if (parameters.length > 0) {
     const needsEventData =
@@ -790,8 +684,8 @@ export const generateSQLCore = (config: ChartConfig, filters: Filter[], paramete
 
   if (config.groupByFields.length > 0) {
     const groupByCols: string[] = []
-    if (hasSegmentBreakdown) {
-      groupByCols.push('base_query.segment_navn')
+    if (cohort.active) {
+      groupByCols.push(cohort.groupByColumn)
     }
     config.groupByFields.forEach((field) => {
       if (field === 'created_at') {
@@ -830,8 +724,8 @@ export const generateSQLCore = (config: ChartConfig, filters: Filter[], paramete
       sql += groupByCols.join(',\n  ')
       sql += '\n'
     }
-  } else if (hasSegmentBreakdown) {
-    sql += 'GROUP BY\n  base_query.segment_navn\n'
+  } else if (cohort.active) {
+    sql += `GROUP BY\n  ${cohort.groupByColumn}\n`
   }
 
   if (config.orderBy && config.orderBy.column && config.orderBy.direction) {

--- a/src/client/shared/types/chart.ts
+++ b/src/client/shared/types/chart.ts
@@ -11,16 +11,16 @@ export interface Filter {
   interactive?: boolean // Add this for interactive mode filters
 }
 
-export interface SegmentPerformed {
+export interface CohortPerformed {
   operator: 'IN' | '=' | '!=' | 'LIKE' | 'STARTS_WITH' | 'ENDS_WITH'
   events: string[]
 }
 
-export interface SegmentDefinition {
+export interface CohortDefinition {
   id: number
   name: string
   filters: Filter[]
-  performed?: SegmentPerformed | null
+  performed?: CohortPerformed | null
 }
 
 export interface Parameter {
@@ -73,7 +73,7 @@ export type { Website }
 export interface ChartConfig {
   website: Website | null
   filters: Filter[]
-  segments?: SegmentDefinition[]
+  cohorts?: CohortDefinition[]
   metrics: Metric[]
   groupByFields: string[]
   orderBy: { column: string; direction: 'ASC' | 'DESC' } | null


### PR DESCRIPTION

## Hva er gjort
### Problemet
Grafbygger bruker SQL-segmentering (kohorter) — altså muligheten til å sammenligne flere brukergrupper side om side i samme spørring. All logikk for dette lå inlined midt i en 897-linje funksjon (`sqlGenerator.ts`) sammen med alt annet: metrikker, gruppering, datofiltere. Det var umulig å teste kohort-SQL isolert, og umulig å vite hvor man skulle endre noe når kohorter fra backend skal inn.
### Løsningen
Vi trakk ut all kohort-SQL til en egen fil: `cohortSql.ts`.
Den eksponerer én funksjon:

```ts
buildCohortClauses(cohorts: CohortDefinition[]): CohortClauses
```
Den tar inn en liste med kohorter og returnerer et lite objekt med de SQL-delene `sqlGenerator` trenger å lime inn:
| Felt | Brukes til |
|------|-----------|
| `active` | Skal vi i det hele tatt bruke kohort-modus? |
| `cte` | `segmented_base AS (...)` CTE-blokken med UNION ALL |
| `selectColumn` | `base_query.segment_navn AS segment` |
| `fromTable` | `segmented_base AS base_query` |
| `groupByColumn` | `base_query.segment_navn` |
`sqlGenerator` kaller den én gang og slotter inn feltene. Den trenger ikke lenger å vite noe om kohort-logikk.
### Også gjort
- Omdøpt `SegmentDefinition` → `CohortDefinition` og `segments` → `cohorts` overalt (chart.ts, sqlGenerator, SegmentBy, Grafbygger, useChartConfig) — koden snakker nå samme språk som domenet
- 17 enhetstester for `buildCohortClauses` — bl.a. filter-operatorer, performed-hendelser, SQL injection-escaping, aktiveringsregler
### TODO (backend-kohorter)
Når `innblikk-backend` sin `cohorts`-branch merges og `CohortDetailDto` er live, er seamen klar. Se kommentaren øverst i `cohortSql.ts` — der står nøyaktig hva som må gjøres (ny `cohortApi.ts`, ny `cohortDtoMapper.ts`, hvilke felter som mappes).